### PR TITLE
Fix dashboard API endpoints and sign-out behavior

### DIFF
--- a/apps/api/src/modules/merchants/merchants.controller.ts
+++ b/apps/api/src/modules/merchants/merchants.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Put,
   Delete,
   Body,
   Param,
@@ -114,5 +115,25 @@ export class MerchantsController {
     }
 
     return this.merchantsService.createWebhookEndpoint(merchant.id, dto.url, dto.events);
+  }
+
+  @Put('webhooks/:id')
+  @ApiOperation({ summary: 'Update webhook endpoint' })
+  @ApiResponse({ status: 200, description: 'Webhook endpoint updated successfully' })
+  async updateWebhook(
+    @Param('id') id: string,
+    @Body() dto: { url?: string; events?: string[]; active?: boolean },
+    @Request() req,
+  ) {
+    const merchant = req.merchant;
+    return this.merchantsService.updateWebhookEndpoint(merchant.id, id, dto);
+  }
+
+  @Delete('webhooks/:id')
+  @ApiOperation({ summary: 'Delete webhook endpoint' })
+  @ApiResponse({ status: 200, description: 'Webhook endpoint deleted successfully' })
+  async deleteWebhook(@Param('id') id: string, @Request() req) {
+    const merchant = req.merchant;
+    return this.merchantsService.deleteWebhookEndpoint(merchant.id, id);
   }
 }

--- a/apps/api/src/modules/merchants/merchants.service.ts
+++ b/apps/api/src/modules/merchants/merchants.service.ts
@@ -192,4 +192,51 @@ export class MerchantsService {
       createdAt: new Date().toISOString(),
     };
   }
+
+  async updateWebhookEndpoint(
+    merchantId: string,
+    id: string,
+    data: { url?: string; events?: string[]; active?: boolean },
+  ) {
+    const merchant = await this.findById(merchantId);
+    if (!merchant) return null;
+
+    if (data.active === false) {
+      await this.merchantRepository.update(merchantId, {
+        webhookUrl: null,
+        webhookSecret: null,
+      });
+      return {
+        id,
+        url: merchant.webhookUrl,
+        events: data.events || [],
+        active: false,
+        createdAt: merchant.createdAt.toISOString(),
+      };
+    }
+
+    if (data.url) {
+      await this.merchantRepository.update(merchantId, { webhookUrl: data.url });
+    }
+
+    return {
+      id,
+      url: data.url || merchant.webhookUrl,
+      events: data.events || [
+        'payment_intent.created',
+        'payment_intent.confirmed',
+        'payment_intent.expired',
+      ],
+      active: data.active ?? true,
+      createdAt: merchant.createdAt.toISOString(),
+    };
+  }
+
+  async deleteWebhookEndpoint(merchantId: string, id: string) {
+    await this.merchantRepository.update(merchantId, {
+      webhookUrl: null,
+      webhookSecret: null,
+    });
+    return { message: 'Webhook endpoint deleted' };
+  }
 }

--- a/web/src/components/dashboard-header.tsx
+++ b/web/src/components/dashboard-header.tsx
@@ -1,10 +1,19 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Settings, LogOut, User } from 'lucide-react';
+import { useAuth } from '@/contexts/auth-context';
 
 export function DashboardHeader() {
   const [showUserMenu, setShowUserMenu] = useState(false);
+  const { logout } = useAuth();
+  const router = useRouter();
+
+  const handleSignOut = () => {
+    logout();
+    router.push('/auth/login');
+  };
 
   return (
     <header className="bg-white border-b border-gray-200">
@@ -50,7 +59,10 @@ export function DashboardHeader() {
                       Settings
                     </button>
                     <hr className="border-gray-100" />
-                    <button className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 w-full text-left">
+                    <button
+                      onClick={handleSignOut}
+                      className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 w-full text-left"
+                    >
                       <LogOut className="w-4 h-4 mr-2" />
                       Sign Out
                     </button>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { PaymentIntentResponseDto } from '@sgate/shared';
+import { getAuthToken } from './auth';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000';
 
@@ -8,9 +9,9 @@ const apiClient = axios.create({
   baseURL: API_BASE,
 });
 
-// Add auth token to requests if available
+// Add auth token from cookies to requests if available
 apiClient.interceptors.request.use((config) => {
-  const token = localStorage.getItem('sgate_api_key');
+  const token = getAuthToken();
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
@@ -60,7 +61,7 @@ export function formatUsd(amount: number): string {
 export const api = {
   async getDashboardStats(): Promise<DashboardStats> {
     try {
-      const response = await apiClient.get('/v1/dashboard/stats');
+      const response = await apiClient.get('/v1/merchants/stats');
       return response.data;
     } catch (error) {
       console.error('Failed to fetch dashboard stats:', error);
@@ -90,7 +91,7 @@ export const api = {
 
   async getApiKeys(): Promise<any[]> {
     try {
-      const response = await apiClient.get('/v1/api-keys');
+      const response = await apiClient.get('/v1/merchants/api-keys');
       return response.data || [];
     } catch (error) {
       console.error('Failed to fetch API keys:', error);
@@ -100,7 +101,7 @@ export const api = {
 
   async createApiKey(data: { name: string; permissions?: string[]; expiresIn?: string | null }): Promise<any> {
     try {
-      const response = await apiClient.post('/v1/api-keys', data);
+      const response = await apiClient.post('/v1/merchants/api-keys', data);
       return response.data;
     } catch (error) {
       console.error('Failed to create API key:', error);
@@ -108,56 +109,27 @@ export const api = {
     }
   },
 
-  async deleteApiKey(id: string): Promise<void> {
-    try {
-      await apiClient.delete(`/v1/api-keys/${id}`);
-    } catch (error) {
-      console.error('Failed to delete API key:', error);
-      throw error;
-    }
-  },
-
   async revokeApiKey(id: string): Promise<void> {
     try {
-      await apiClient.delete(`/v1/api-keys/${id}`);
+      await apiClient.delete(`/v1/merchants/api-keys/${id}`);
     } catch (error) {
       console.error('Failed to revoke API key:', error);
       throw error;
     }
   },
-
-  async getWebhooks(): Promise<any[]> {
-    try {
-      const response = await apiClient.get('/v1/webhooks');
-      return response.data || [];
-    } catch (error) {
-      console.error('Failed to fetch webhooks:', error);
-      return [];
-    }
-  },
-
   async getWebhookEndpoints(): Promise<any[]> {
     try {
-      const response = await apiClient.get('/v1/webhooks');
+      const response = await apiClient.get('/v1/merchants/webhooks');
       return response.data || [];
     } catch (error) {
       console.error('Failed to fetch webhooks:', error);
       return [];
-    }
-  },
-
-  async updateWebhook(data: any): Promise<void> {
-    try {
-      await apiClient.put('/v1/webhooks', data);
-    } catch (error) {
-      console.error('Failed to update webhook:', error);
-      throw error;
     }
   },
 
   async createWebhookEndpoint(url: string, events: string[]): Promise<void> {
     try {
-      await apiClient.post('/v1/webhooks', { url, events });
+      await apiClient.post('/v1/merchants/webhooks', { url, events });
     } catch (error) {
       console.error('Failed to create webhook endpoint:', error);
       throw error;
@@ -166,7 +138,7 @@ export const api = {
 
   async deleteWebhookEndpoint(id: string): Promise<void> {
     try {
-      await apiClient.delete(`/v1/webhooks/${id}`);
+      await apiClient.delete(`/v1/merchants/webhooks/${id}`);
     } catch (error) {
       console.error('Failed to delete webhook endpoint:', error);
       throw error;
@@ -175,7 +147,7 @@ export const api = {
 
   async updateWebhookEndpoint(id: string, data: any): Promise<void> {
     try {
-      await apiClient.put(`/v1/webhooks/${id}`, data);
+      await apiClient.put(`/v1/merchants/webhooks/${id}`, data);
     } catch (error) {
       console.error('Failed to update webhook endpoint:', error);
       throw error;

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -14,7 +14,9 @@
     "jsx": "preserve",
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@sgate/shared": ["../packages/shared/src"],
+      "@sgate/shared/*": ["../packages/shared/src/*"]
     },
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- wire dashboard header sign-out to auth context and login redirect
- use auth cookie for API requests and correct merchant API endpoints
- add webhook update/delete endpoints and type mappings for shared package

## Testing
- `npm run lint` (failed: ESLint config missing)
- `npm run typecheck`
- `npm run lint` (backend failed: ESLint config missing)
- `npm test` (backend failed: module resolution and types)
- `npm run typecheck` (backend failed: TS errors)


------
https://chatgpt.com/codex/tasks/task_e_68b9ca21955c832d92fc043ef875905d