### PR TITLE
feat: make CORS origins configurable

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -26,7 +26,9 @@ async function bootstrap() {
 
   // Enhanced CORS with security considerations
   const isDevelopment = process.env.NODE_ENV === 'development';
-  
+  const corsOrigin = configService.get<string>('cors.origin');
+  const corsCredentials = configService.get<boolean>('cors.credentials');
+
   if (isDevelopment) {
     // Development: Permissive CORS for testing
     app.enableCors({
@@ -34,27 +36,31 @@ async function bootstrap() {
         logger.debug(`CORS request from origin: ${origin}`);
         callback(null, true); // Allow all origins in development
       },
-      credentials: true,
+      credentials: corsCredentials ?? true,
       methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH'],
       allowedHeaders: [
-        'Content-Type', 
-        'Authorization', 
-        'X-Requested-With', 
-        'Accept', 
-        'Origin', 
-        'X-Request-ID'
+        'Content-Type',
+        'Authorization',
+        'X-Requested-With',
+        'Accept',
+        'Origin',
+        'X-Request-ID',
       ],
       exposedHeaders: ['X-Request-ID', 'X-RateLimit-Limit', 'X-RateLimit-Remaining'],
     });
   } else {
     // Production: Restricted CORS
+    const defaultOrigins = [
+      'https://checkout.sgate.com',
+      'https://dashboard.sgate.com',
+      'https://sgate.com',
+    ];
+    const origins = corsOrigin
+      ? corsOrigin.split(',').map((o) => o.trim())
+      : defaultOrigins;
     app.enableCors({
-      origin: [
-        'https://checkout.sgate.com',
-        'https://dashboard.sgate.com',
-        'https://sgate.com',
-      ],
-      credentials: true,
+      origin: origins,
+      credentials: corsCredentials ?? true,
       methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH'],
       allowedHeaders: [
         'Content-Type',

--- a/docs/PRODUCTION_DEPLOYMENT.md
+++ b/docs/PRODUCTION_DEPLOYMENT.md
@@ -36,7 +36,7 @@ JWT_SECRET=your_secure_jwt_secret_here
 
 # External Services
 SENTRY_DSN=https://your-sentry-dsn@sentry.io/project-id
-CORS_ORIGIN=https://yourdomain.com
+CORS_ORIGIN=https://yourdomain.com,https://dashboard.yourdomain.com # Comma-separated origins are supported
 
 # Monitoring
 GRAFANA_PASSWORD=your_secure_grafana_password_here


### PR DESCRIPTION
## Summary
- make API CORS origins configurable via env var
- document CORS_ORIGIN env var supports multiple origins

## Testing
- `npm test` (fails: Test Suites: 4 failed, 4 total)
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68b9ce089f1c832d956b9dbc8e4ca81a